### PR TITLE
Fix wrong cast in check_ceph_df

### DIFF
--- a/src/check_ceph_df
+++ b/src/check_ceph_df
@@ -114,7 +114,7 @@ def main():
         # print 'DEBUG:', globalvals
         # finally 4th element contains percentual value
         # print 'DEBUG USAGE:', globalvals[3]
-        global_usage_percent = globalvals[3]
+        global_usage_percent = float(globalvals[3])
         global_available_space = globalvals[1]
         global_total_space = globalvals[0]
         # print 'DEBUG WARNLEVEL:', args.warn


### PR DESCRIPTION
I saw this in prod:
 CRITICAL: global RAW usage of 9.78% is above 80% (5252G of 5822G free) 

There doesn't seem to be any other range comparisons between strings, so that's why I didn't make a bigger change.

Let me know if you need any info but it's straightforward.

Thanks in advance!!!!