### PR TITLE
Parse warn & critical as floats

### DIFF
--- a/src/check_ceph_df
+++ b/src/check_ceph_df
@@ -42,8 +42,8 @@ def main():
     parser.add_argument('-n','--name', help='ceph client name')
     parser.add_argument('-k','--keyring', help='ceph client keyring file')
     parser.add_argument('-d','--detail', help="show pool details on warn and critical", action='store_true')
-    parser.add_argument('-W','--warn', help="warn above this percent RAW USED")
-    parser.add_argument('-C','--critical', help="critical alert above this percent RAW USED")
+    parser.add_argument('-W','--warn', help="warn above this percent RAW USED", type=float)
+    parser.add_argument('-C','--critical', help="critical alert above this percent RAW USED", type=float)
     parser.add_argument('-V','--version', help='show version and exit', action='store_true')
     args = parser.parse_args()
 


### PR DESCRIPTION
Added `type=float` to the definition of the _warn_ and _critical_ threshold arguments. Previously they were parsed as text and the comparison with `global_usage_percent` didn't work properly.