### PR TITLE
check_ceph_rgw: add client name option

### DIFF
--- a/src/check_ceph_rgw
+++ b/src/check_ceph_rgw
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+# changes:
+# 2017-07-27: add client name option, André Klausnitzer <info@b1-systems.de>
 
 import argparse
 import os
@@ -43,6 +45,7 @@ def main():
   parser.add_argument('-e','--exe', help='radosgw-admin executable [%s]' % RGW_COMMAND)
   parser.add_argument('-c','--conf', help='alternative ceph conf file')
   parser.add_argument('-i','--id', help='ceph client id')
+  parser.add_argument('-n','--name', help='ceph client name (type.id)')
   parser.add_argument('-V','--version', help='show version and exit', action='store_true')
   args = parser.parse_args()
 
@@ -68,6 +71,9 @@ def main():
   if args.id:
     rgw_cmd.append('-i')
     rgw_cmd.append(args.id)
+  if args.name:
+    rgw_cmd.append('-n')
+    rgw_cmd.append(args.name)
   rgw_cmd.append('bucket')
   rgw_cmd.append('stats')
 


### PR DESCRIPTION
With this option `-n|--name` a user is able to fetch status from radosgw-admin with name.

Reason: I have noticed that option `-i|--id` does not lead to the usage of the corresponding client keyring. It falls back to the admin keyring which is not accessible when check runs as user "nagios". With `radosgw-admin -n client.name` it is possible to use the same keyring defined in "/etc/ceph/ceph.conf" for radosgw. In this case the admin keyring must not be made world readable, instead only the nagios user can be added to the ceph group to access the keyring.