### PR TITLE
Stop error from ceph command being silenced

### DIFF
--- a/src/check_ceph_health
+++ b/src/check_ceph_health
@@ -122,7 +122,7 @@ def main():
     try:
         output = json.loads(output)
     except ValueError:
-        return STATUS_UNKNOWN
+        output = dict()
 
     # parse output
     # print "output:", output


### PR DESCRIPTION
If output from the ceph command returns an error the function returns. This
circumvents the printing of `err` later in the function.

This change defaults to an empty dictionary instead. This make it possible to
handle the error with existing code.