### PR TITLE
Fixed check_ceph_osd for Ceph Octopus.

### DIFF
--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -15,9 +15,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-# 1.5.2 (2019-06-16) Martin Seener: fixed regex to work with Ceph Nautilus (14.2.x)
+# 1.6.0 (2022-05-02) Logan Skidmore: fixed regex to work with Ceph Octopus (15.x.x)
 
-from __future__ import print_function
 import argparse
 import os
 import re
@@ -55,26 +54,26 @@ def main():
   # validate args
   ceph_exec = args.exe if args.exe else CEPH_COMMAND
   if not os.path.exists(ceph_exec):
-    print("OSD ERROR: ceph executable '%s' doesn't exist" % ceph_exec)
+    print "OSD ERROR: ceph executable '%s' doesn't exist" % ceph_exec
     return STATUS_UNKNOWN
 
   if args.version:
-    print('version %s' % __version__)
+    print 'version %s' % __version__
     return STATUS_OK
 
   if args.conf and not os.path.exists(args.conf):
-    print("OSD ERROR: ceph conf file '%s' doesn't exist" % args.conf)
+    print "OSD ERROR: ceph conf file '%s' doesn't exist" % args.conf
     return STATUS_UNKNOWN
 
   if args.keyring and not os.path.exists(args.keyring):
-    print("OSD ERROR: keyring file '%s' doesn't exist" % args.keyring)
+    print "OSD ERROR: keyring file '%s' doesn't exist" % args.keyring
     return STATUS_UNKNOWN
 
   if not args.osdid:
     args.osdid = '[^ ]*'
 
   if not args.host:
-    print("OSD ERROR: no OSD hostname given")
+    print "OSD ERROR: no OSD hostname given"
     return STATUS_UNKNOWN
 
   try:
@@ -83,7 +82,7 @@ def main():
     if addrinfo[0][0] == socket.AF_INET6:
       args.host = "[%s]" % args.host
   except:
-    print('OSD ERROR: could not resolve %s' % args.host)
+    print 'OSD ERROR: could not resolve %s' % args.host
     return STATUS_UNKNOWN
 
 
@@ -103,51 +102,46 @@ def main():
       ceph_cmd.append(args.keyring)
   ceph_cmd.append('osd')
   ceph_cmd.append('dump')
-
-  # exec command
-  p = subprocess.Popen(ceph_cmd,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-  output, err = p.communicate()
-  output = output.decode('utf8')
-
-  if err or not output:
-    print("OSD ERROR: %s" % err)
-    return STATUS_ERROR
+# exec command
+  print ceph_cmd
 
   # escape IPv4 host address
   osd_host = args.host.replace('.', '\.')
   # escape IPv6 host address
   osd_host = osd_host.replace('[', '\[')
   osd_host = osd_host.replace(']', '\]')
-  up = re.findall(r"^(osd\.%s) up.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)
+  print output
+  up = re.findall(r"^(osd\.%s) up.*(%s):" % (args.osdid, osd_host), output, re.MULTILINE)
+  # print up
   if args.out:
-    down = re.findall(r"^(osd\.%s) down.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)
-    down_in = re.findall(r"^(osd\.%s) down[ ]+in.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)
-    down_out = re.findall(r"^(osd\.%s) down[ ]+out.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)
+    down = re.findall(r"^(osd\.%s) down.*(%s):" % (args.osdid, osd_host), output, re.MULTILINE)
+    down_in = re.findall(r"^(osd\.%s) down[ ]+in.*(%s):" % (args.osdid, osd_host), output, re.MULTILINE)
+    down_out = re.findall(r"^(osd\.%s) down[ ]+out.*(%s):" % (args.osdid, osd_host), output, re.MULTILINE)
   else:
-    down = re.findall(r"^(osd\.%s) down[ ]+in.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)
+    down = re.findall(r"^(osd\.%s) down[ ]+in.*(%s):" % (args.osdid, osd_host), output, re.MULTILINE)
     down_in = down
-    down_out = re.findall(r"^(osd\.%s) down[ ]+out.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)
+    down_out = re.findall(r"^(osd\.%s) down[ ]+out.*(%s):" % (args.osdid, osd_host), output, re.MULTILINE)
 
   if down:
-    print("OSD %s: Down OSD%s on %s: %s" % ('CRITICAL' if len(down)>=args.crit else 'WARNING' ,'s' if len(down)>1 else '', args.host, " ".join(down)))
-    print("Up OSDs: " + " ".join(up))
-    print("Down+In OSDs: " + " ".join(down_in))
-    print("Down+Out OSDs: " + " ".join(down_out))
-    print("| 'osd_up'=%d 'osd_down_in'=%d;;%d 'osd_down_out'=%d;;%d" % (len(up), len(down_in), args.crit, len(down_out), args.crit))
+    print "OSD %s: Down OSD%s on %s: %s" % ('CRITICAL' if len(down)>=args.crit else 'WARNING' ,'s' if len(down)>1 else '', args.host, " ".join(down))
+    print "Up OSDs: " + " ".join(str(i) for i in up)
+    print "Down+In OSDs: " + " ".join(str(i) for i in down_in)
+    print "Down+Out OSDs: " + " ".join(str(i) for i in down_out)
+    print "| 'osd_up'=%d 'osd_down_in'=%d;;%d 'osd_down_out'=%d;;%d" % (len(up), len(down_in), args.crit, len(down_out), args.crit)
     if len(down)>=args.crit:
       return STATUS_ERROR
     else:
       return STATUS_WARNING
 
   if up:
-    print("OSD OK")
+    print "OSD OK"
     print "Up OSDs: " + " ".join(str(i) for i in up)
-    print("Down+In OSDs: " + " ".join(down_in))
-    print("Down+Out OSDs: " + " ".join(down_out))
-    print("| 'osd_up'=%d 'osd_down_in'=%d;;%d 'osd_down_out'=%d;;%d" % (len(up), len(down_in), args.crit, len(down_out), args.crit))
+    print "Down+In OSDs: " + " ".join(str(i) for i in down_in)
+    print "Down+Out OSDs: " + " ".join(str(i) for i in down_out)
+    print "| 'osd_up'=%d 'osd_down_in'=%d;;%d 'osd_down_out'=%d;;%d" % (len(up), len(down_in), args.crit, len(down_out), args.crit)
     return STATUS_OK
 
-  print("OSD WARN: no OSD.%s found on host %s" % (args.osdid, args.host))
+  print "OSD WARN: no OSD.%s found on host %s" % (args.osdid, args.host)
   return STATUS_WARNING
 
 if __name__ == "__main__":

--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -141,7 +141,7 @@ def main():
 
   if up:
     print("OSD OK")
-    print("Up OSDs: " + " ".join(up))
+    print "Up OSDs: " + " ".join(str(i) for i in up)
     print("Down+In OSDs: " + " ".join(down_in))
     print("Down+Out OSDs: " + " ".join(down_out))
     print("| 'osd_up'=%d 'osd_down_in'=%d;;%d 'osd_down_out'=%d;;%d" % (len(up), len(down_in), args.crit, len(down_out), args.crit))


### PR DESCRIPTION
Removed unnecessary parentheses for Python 3, fixed regex variable import, and added a loop to the print statements to properly format the aggregate OSD states.

The findall regex function of python3 outputs a tuple when searching for multiple statements. This is in contrast to prior versions which output an array of strings, requiring us to loop through joining the tuples prior to printing.