### PR TITLE
check_ceph_osd_db: Decode bytes output to string

### DIFF
--- a/src/check_ceph_osd_db
+++ b/src/check_ceph_osd_db
@@ -101,7 +101,7 @@ def main():
     osd_host = osd_host.replace('[', '\[')
     osd_host = osd_host.replace(']', '\]')
 
-    osds_up = re.findall(r"^(osd\.[^ ]*) up.*%s:" % (osd_host), output, re.MULTILINE)
+    osds_up = re.findall(r"^(osd\.[^ ]*) up.*%s:" % (osd_host), output.decode('utf-8'), re.MULTILINE)
 
     final_status = STATUS_OK
     lines = []


### PR DESCRIPTION
Avoids `TypeError: cannot use a string pattern on a bytes-like object` when executing `re.findall()`.

`Popen.communicate()` returns bytes if the streams weren't opened in text mode, which is not the case here, as far as I can tell. See https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate 