### PR TITLE
Simplify host address escaping in check_ceph_osd

### DIFF
--- a/src/check_ceph_osd
+++ b/src/check_ceph_osd
@@ -113,11 +113,9 @@ def main():
     print("OSD ERROR: %s" % err)
     return STATUS_ERROR
 
-  # escape IPv4 host address
-  osd_host = args.host.replace('.', '\.')
-  # escape IPv6 host address
-  osd_host = osd_host.replace('[', '\[')
-  osd_host = osd_host.replace(']', '\]')
+  # Automatically escapes all special regex characters (., [, ], etc.)
+  osd_host = re.escape(args.host)
+
   up = re.findall(r"^(osd\.%s) up.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)
   if args.out:
     down = re.findall(r"^(osd\.%s) down.*%s:" % (args.osdid, osd_host), output, re.MULTILINE)


### PR DESCRIPTION
Replaced manual escaping of IPv4 and IPv6 host addresses with automatic escaping using re.escape().